### PR TITLE
fixing the Pagination links

### DIFF
--- a/ucp.php
+++ b/ucp.php
@@ -363,7 +363,7 @@ switch (g('go'))
 		$linkgoto		= $config['siteurl'] . (
                                     $config['mod_writer']
                                     ?  'fileuser-' . $user_id . ($currentPage > 1  && $currentPage <= $total_pages ? '-' . $currentPage : '')  . '.html'
-                                    : 'ucp.php?go=fileuser' . ($currentPage > 1 &&  $currentPage <= $total_pages ? '&amp;page=' . $currentPage : '')
+                                    : 'ucp.php?go=fileuser' . ( ig('id') ? ( g('id' , 'int') == $usrcp->id() ? '' : '&amp;id=' . g('id') ) : null  )
                             );
 
 		$page_nums		= $Pager->print_nums(str_replace('.html', '', $linkgoto));


### PR DESCRIPTION
when the guest visiting fileuser and he want to move to the second page ,
the link going to " example.com/kleeja/ucp.php?go=fileuser&page=1&page=2 " without defining the id of userfile
and u can see also the $_GET['page'] is defined 2 time